### PR TITLE
Fix DecimalFormat for German (and possible other) systems

### DIFF
--- a/src/main/java/com/blocklaunch/blwarps/Warp.java
+++ b/src/main/java/com/blocklaunch/blwarps/Warp.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.flowpowered.math.vector.Vector3d;
 
-import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,11 +62,6 @@ public class Warp extends WarpBase {
             this.position = new Vector3d(this.x, this.y, this.z);
         }
         return this.position;
-    }
-
-    private double formatDouble(double d) {
-        DecimalFormat f = new DecimalFormat("##.00");
-        return Double.valueOf(f.format(d));
     }
 
     public double getX() {

--- a/src/main/java/com/blocklaunch/blwarps/WarpBase.java
+++ b/src/main/java/com/blocklaunch/blwarps/WarpBase.java
@@ -1,6 +1,9 @@
 package com.blocklaunch.blwarps;
 
 import javax.validation.constraints.Size;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 
 public abstract class WarpBase {
 
@@ -32,6 +35,11 @@ public abstract class WarpBase {
 
     public void setWorld(String world) {
         this.world = world;
+    }
+
+    protected double formatDouble(double d) {
+        DecimalFormat f = new DecimalFormat("##.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+        return Double.valueOf(f.format(d));
     }
 
 }

--- a/src/main/java/com/blocklaunch/blwarps/region/WarpRegion.java
+++ b/src/main/java/com/blocklaunch/blwarps/region/WarpRegion.java
@@ -4,8 +4,6 @@ import com.blocklaunch.blwarps.WarpBase;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.flowpowered.math.vector.Vector3d;
 
-import java.text.DecimalFormat;
-
 public class WarpRegion extends WarpBase {
 
     private String linkedWarpName;
@@ -55,11 +53,6 @@ public class WarpRegion extends WarpBase {
                 && this.maxLoc.getY() > warpRegion.getMinLoc().getY() && this.minLoc.getY() < warpRegion.getMaxLoc().getY()
                 && this.maxLoc.getZ() > warpRegion.getMinLoc().getZ() && this.minLoc.getZ() < warpRegion.getMaxLoc().getZ());
 
-    }
-
-    private double formatDouble(double d) {
-        DecimalFormat f = new DecimalFormat("##.00");
-        return Double.valueOf(f.format(d));
     }
 
     public String getLinkedWarpName() {


### PR DESCRIPTION
Trying to add a warp on a German system results in an NumberFormatException.

```
[18:22:45] [Server thread/ERROR] [Sponge/]: Error occurred while executing command 'warp set test 2450 87 2276' for source EntityPlayerMP['r15ch13'/119, l='vanilla', x=2450,79, y=87,00, z=2276,50]: For input string: "2450,00"
java.lang.NumberFormatException: For input string: "2450,00"
    at sun.misc.FloatingDecimal.readJavaFormatString(Unknown Source) ~[?:1.8.0_51]
    at sun.misc.FloatingDecimal.parseDouble(Unknown Source) ~[?:1.8.0_51]
    at java.lang.Double.parseDouble(Unknown Source) ~[?:1.8.0_51]
    at java.lang.Double.valueOf(Unknown Source) ~[?:1.8.0_51]
    at com.blocklaunch.blwarps.Warp.formatDouble(Warp.java:70) ~[Warp.class:?]
    at com.blocklaunch.blwarps.Warp.<init>(Warp.java:37) ~[Warp.class:?]
    at com.blocklaunch.blwarps.commands.executors.CreateWarpExecutor.execute(CreateWarpExecutor.java:48) ~[CreateWarpExecutor.class:?]
    at org.spongepowered.api.util.command.args.ChildCommandElementExecutor.execute(ChildCommandElementExecutor.java:181) ~[ChildCommandElementExecutor.class:1.8-1487-2.1DEV-520+unknown-b520.git-unknown]
    at org.spongepowered.api.util.command.spec.CommandSpec.process(CommandSpec.java:333) ~[CommandSpec.class:1.8-1487-2.1DEV-520+unknown-b520.git-unknown]
    at org.spongepowered.api.util.command.dispatcher.SimpleDispatcher.process(SimpleDispatcher.java:342) ~[SimpleDispatcher.class:1.8-1487-2.1DEV-520+unknown-b520.git-unknown]
    at org.spongepowered.api.service.command.SimpleCommandService.process(SimpleCommandService.java:243) [SimpleCommandService.class:1.8-1487-2.1DEV-520+unknown-b520.git-unknown]
    at net.minecraft.command.ServerCommandManager.func_71556_a(SourceFile:85) [cl.class:?]
    at net.minecraft.network.NetHandlerPlayServer.func_147361_d(NetHandlerPlayServer.java:812) [rj.class:?]
    at net.minecraft.network.NetHandlerPlayServer.func_147354_a(NetHandlerPlayServer.java:791) [rj.class:?]
    at net.minecraft.network.play.client.C01PacketChatMessage.func_180757_a(SourceFile:37) [lu.class:?]
    at net.minecraft.network.play.client.C01PacketChatMessage.func_148833_a(SourceFile:9) [lu.class:?]
    at net.minecraft.network.PacketThreadUtil$1.run(SourceFile:13) [ih.class:?]
    at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source) [?:1.8.0_51]
    at java.util.concurrent.FutureTask.run(Unknown Source) [?:1.8.0_51]
    at net.minecraftforge.fml.common.FMLCommonHandler.callFuture(FMLCommonHandler.java:714) [FMLCommonHandler.class:?]
    at net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:656) [MinecraftServer.class:?]
    at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:364) [po.class:?]
    at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:598) [MinecraftServer.class:?]
    at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:478) [MinecraftServer.class:?]
    at java.lang.Thread.run(Unknown Source) [?:1.8.0_51]
```
